### PR TITLE
Add scan method noIsolateScan with no isolates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ## 1.0.1
 
-- Added `timeout` argument to TCPScanner constructor. It defines connection timeout in milliseconds while scanner waits for port response.  
+- Added `timeout` argument to TCPScanner constructor. It defines connection timeout in milliseconds while scanner waits for port response.
 
 ## 1.1.0
 - Added ability of multithread scanning
 - Added ports shuffle option
 - Fixed elapsed time calculation bug
+
+
+## 1.1.2
+- Added ability to scan with or without multithreading

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Scanner performs sequential connect scan of specified ports or port ranges.
 
 ## Usage
-To use this package add `tcp_scanner` as a dependency in your pubspec.yaml. To run scan use TCPScanner class. 
+To use this package add `tcp_scanner` as a dependency in your pubspec.yaml. To run scan use TCPScanner class.
 ScanResult contains scanning report. If you need to get running scan status, you have to use TCPScanner.scanResult field.
 
 Scan specified ports:
@@ -35,7 +35,7 @@ Elapsed time:  0.03s
 ```
 
 If you scan unreachable hosts, ports are not added to `closed` list. You can set timeout time using `timeout` argument in TCPScanner constructor. By default timeout is 100ms.
-Scan below elapsed about 900 ms because it scans 3 ports with 300ms timeout. 
+Scan below elapsed about 900 ms because it scans 3 ports with 300ms timeout.
 ```dart
 import 'package:tcp_scanner/tcp_scanner.dart';
 
@@ -155,6 +155,8 @@ Scanned ports: 20-5000
 Open ports:    [1028, 1025, 1026, 1024, 1027]
 Elapsed time:  17.62s
 ```
+
+If for any reason you do not want scanning on isolates, use the `noIsolateScan` method instead of `scan`.
 
 ## Features and bugs
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tcp_scanner
 description: TCP port scanner. Scan ports sequentially using connect method.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/shpak86/tcp_scanner
 author: ash <shpakovsky86@gmail.com>
 


### PR DESCRIPTION
I added a second `noIsolateScan` method to optionally scan with no isolates.

I was having issues using this package with the `Jaguar` web-framework's hot-reloading package, where I used this package to scan for the next available port. It uses the dart VM's `--observe` and `vm_service` package to hot-reload isolates.

I was getting this error: 

![image](https://user-images.githubusercontent.com/302171/72484459-49db7380-37d2-11ea-8416-41dfcdba7403.png)

Obviously, I only wanted to scan a couple available ports.